### PR TITLE
Enabled Multidex and removed absolute path to firebase_cpp_sdk

### DIFF
--- a/proj.android/app/build.gradle
+++ b/proj.android/app/build.gradle
@@ -9,6 +9,7 @@ android {
         applicationId "com.fsk00x.TicTacToe"
         minSdkVersion PROP_MIN_SDK_VERSION
         targetSdkVersion PROP_TARGET_SDK_VERSION
+	multiDexEnabled true
         versionCode 1
         versionName "1.0"
 

--- a/proj.android/gradle.properties
+++ b/proj.android/gradle.properties
@@ -46,4 +46,4 @@ PROP_BUILD_TYPE=cmake
 #RELEASE_KEY_PASSWORD=password of key
 
 
-systemProp.firebase_cpp_sdk.dir=/Users/rahul/Documents/TicTacToe/TicTacToe/firebase_cpp_sdk
+systemProp.firebase_cpp_sdk.dir= ../firebase_cpp_sdk


### PR DESCRIPTION
Enabled Multidex on app/build.gradle and removed absolute path to firebase_cpp_sdk on gradle.properties